### PR TITLE
Add support for multiple assignment groups in submission tree

### DIFF
--- a/src/main/java/me/akainth/ambient/actions/SubmissionConfirmationDialog.java
+++ b/src/main/java/me/akainth/ambient/actions/SubmissionConfirmationDialog.java
@@ -101,6 +101,7 @@ public class SubmissionConfirmationDialog extends DialogWrapper {
                 return model.buildTreeModel();
             }
         });
+        assignmentPicker.getTree().setRootVisible(false);
     }
 
     public SyncedTreeView<SubmissionRoot> getAssignmentPicker() {

--- a/src/main/java/me/akainth/ambient/ui/SyncedTreeView.java
+++ b/src/main/java/me/akainth/ambient/ui/SyncedTreeView.java
@@ -52,6 +52,7 @@ public class SyncedTreeView<T> {
         clearTree();
         updatePreview();
 
+        tree.setRootVisible(false);
         tree.addMouseListener(new MouseListener() {
             @Override
             public void mouseClicked(MouseEvent e) {

--- a/src/main/java/me/akainth/ambient/ui/SyncedTreeView.java
+++ b/src/main/java/me/akainth/ambient/ui/SyncedTreeView.java
@@ -52,7 +52,6 @@ public class SyncedTreeView<T> {
         clearTree();
         updatePreview();
 
-        tree.setRootVisible(false);
         tree.addMouseListener(new MouseListener() {
             @Override
             public void mouseClicked(MouseEvent e) {

--- a/src/main/kotlin/me/akainth/ambient/submitter/AssignmentGroup.kt
+++ b/src/main/kotlin/me/akainth/ambient/submitter/AssignmentGroup.kt
@@ -19,4 +19,6 @@ class AssignmentGroup(source: Element) {
             Assignment(assignmentElement)
         }
     }
+
+    override fun toString(): String = name
 }

--- a/src/main/kotlin/me/akainth/ambient/submitter/SubmissionRoot.kt
+++ b/src/main/kotlin/me/akainth/ambient/submitter/SubmissionRoot.kt
@@ -15,9 +15,15 @@ class SubmissionRoot constructor(submissionRootDocument: Document) {
         submissionRootDocument.getElementsByTagName("submission-targets").item(0) as Element
 
     fun buildTreeModel(): DefaultTreeModel {
-        val root = DefaultMutableTreeNode(assignmentGroup.name)
+        val root = DefaultMutableTreeNode("Assignment Groups")
 
-        assignments.map { DefaultMutableTreeNode(it) }.forEach {
+        assignmentGroups.map {
+            val node = DefaultMutableTreeNode(it)
+            it.assignments
+                .map { DefaultMutableTreeNode(it) }
+                .forEach { node.add(it) }
+            node
+        }.forEach {
             root.add(it)
         }
 
@@ -33,12 +39,12 @@ class SubmissionRoot constructor(submissionRootDocument: Document) {
             }
         }
 
-    private val assignmentGroup: AssignmentGroup
+    private val assignmentGroups: Array<AssignmentGroup>
         get() {
-            val assignmentGroupElement =
-                submissionTargetElement.getElementsByTagName("assignment-group").item(0) as Element
-            return AssignmentGroup(assignmentGroupElement)
+            val assignmentGroupNodes = submissionTargetElement.getElementsByTagName("assignment-group")
+            return Array(assignmentGroupNodes.length) {
+                val assignmentGroupElement = assignmentGroupNodes.item(it) as Element
+                AssignmentGroup(assignmentGroupElement)
+            }
         }
-
-    private val assignments = assignmentGroup.assignments
 }


### PR DESCRIPTION
When submitting an assignment, the plugin only displayed the first "assignment group" element in the XML returned by Web-CAT. At my school, at least, the assignment groups correspond to classes, so I couldn't even select my class.

This pull request makes a root node labeled "Assignment Groups" and then turns each assignment group element into its own node so any assignment from any assignment group can be selected.

The root node is then hidden using `setRootVisible(False)` so the user is simply presented with a list of assignment groups and assignments. Should this be set from inside a `.form` instead?

The change is designed to be non-breaking, but you should test this with your institution to make sure it still works.

I've never used Kotlin before, so feedback welcome on any technical or style issues!